### PR TITLE
Use the nginx reactive layer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
 # Overview
 
-This subordinate charm deploys an application to mirror and periodically sync
-an Ubuntu archive.
-
-It's meant to be deployed alongside apache2 so that the mirrored archive can be
-exposed.
+This charm deploys an application to mirror and periodically sync an Ubuntu
+archive and expose it through static file serve via Nginx.

--- a/layer.yaml
+++ b/layer.yaml
@@ -1,9 +1,10 @@
 includes:
   - 'layer:basic'
-  - 'interface:apache-website'
+  - 'layer:nginx'
 repo: https://github.com/CanonicalLtd/archive-auth-mirror
 options:
   basic:
     packages:
       - gnupg
+      - reprepro
     use_venv: true

--- a/lib/charms/archive_auth_mirror/utils.py
+++ b/lib/charms/archive_auth_mirror/utils.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-import textwrap
 import shutil
 
 from charmhelpers.core import hookenv
@@ -39,37 +38,11 @@ def get_virtualhost_name(hookenv=hookenv):
     return service_url or hookenv.unit_public_ip()
 
 
-def configure_website_relation():
-    """Configure the 'static-website' relation."""
-    domain = get_virtualhost_name()
-    config = get_website_relation_config(domain)
-    for relation_id in hookenv.relation_ids('static-website'):
-        hookenv.relation_set(relation_id, config)
-
-
-def get_website_relation_config(domain):
-    """Return the configuration for the 'static-website' relation."""
-    port = 80
+def get_virtualhost_config(hookenv=hookenv):
+    '''Return the configuration for the static virtuahost.'''
     paths = get_paths()
-    vhost_config = textwrap.dedent(
-        '''
-        <VirtualHost {domain}:{port}>
-          DocumentRoot "{document_root}"
-
-          <Location />
-            Require all granted
-            Options +Indexes
-          </Location>
-        </VirtualHost>
-        '''.format(
-            domain=domain, port=port,
-            document_root=paths['static']))
-    return {
-        'domain': domain,
-        'enabled': True,
-        'site_config': vhost_config,
-        'site_modules': ['autoindex'],
-        'ports': [port]}
+    domain = get_virtualhost_name(hookenv=hookenv)
+    return {'domain': domain, 'document_root': str(paths['static'])}
 
 
 def install_resources(base_dir=None):

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,15 +1,9 @@
 name: archive-auth-mirror
-summary: Sync an Ubuntu repository and provide an authenticate mirror.
+summary: Sync an Ubuntu repository and provide an authenticate mirror
 maintainer: Canonical Landscape Team <landscape-crew@lists.canonical.com>
 description: |
-  This subordinate charm provides an HTTPS mirror with BasicAuth of an Ubuntu
-  archive.
+  This charm provides an HTTPS mirror with BasicAuth of an Ubuntu archive.
 series:
   - xenial
 tags:
   - security
-subordinate: true
-requires:
-  static-website:
-    interface: apache-website
-    scope: container

--- a/reactive/archive_auth_mirror.py
+++ b/reactive/archive_auth_mirror.py
@@ -1,60 +1,51 @@
-
-from charms.reactive import (
-    when,
-    when_not,
-    set_state,
-)
 from charmhelpers.core import hookenv
-from charmhelpers.fetch import apt_install
 
-from charms.archive_auth_mirror.utils import (
-    configure_website_relation,
-    get_website_relation_config,
-    install_resources,
-)
+from charms.reactive import when, when_not
 
-from charms.archive_auth_mirror import gpg, reprepro
+from charms.layer.nginx import configure_site
+from charms.archive_auth_mirror import gpg, reprepro, utils
 
 
-PACKAGES = ['reprepro']
+@when('nginx.available')
+def configure_webapp():
+    utils.install_resources()
+    configure_static_serve()
 
 
-@when_not('archive-auth-mirror.installed')
-def install():
-    apt_install(PACKAGES, fatal=True)
-    install_resources()
-    set_state('archive-auth-mirror.installed')
+@when('nginx.available', 'website.available')
+def configure_website(website):
+    website.configure(port=hookenv.config()['port'])
 
 
-@when('config.changed.service-url')
-def config_service_url():
-    configure_website_relation()
+@when('config.changed.mirror-uri')
+def config_mirror_uri_changed():
+    configure_static_serve()
 
 
-@when('config.changed')
-def config_changed():
+@when('config.set.mirror-uri', 'config.set.mirror-archs',
+      'config.set.mirror-gpg-key', 'config.set.sign-gpg-key')
+def config_set():
     config = hookenv.config()
-    mirror_uri = config.get('mirror-uri')
-    mirror_archs = config.get('mirror-archs')
-    mirror_key = config.get('mirror-gpg-key')
-    sign_key = config.get('sign-gpg-key')
 
-    if mirror_uri and mirror_archs and mirror_key and sign_key:
-        mirror_fprint, sign_fprint = gpg.import_gpg_keys(mirror_key, sign_key)
-        reprepro.configure_reprepro(
-            mirror_uri, mirror_archs, mirror_fprint, sign_fprint)
-        hookenv.log('Configured mirroring')
-    else:
-        reprepro.disable_mirroring()
-        hookenv.log('Not all required configs set, mirroring is disabled')
+    # configure mirroring
+    mirror_fprint, sign_fprint = gpg.import_gpg_keys(
+        config['mirror-gpg-key'], config['sign-gpg-key'])
+    reprepro.configure_reprepro(
+        config['mirror-uri'], config['mirror-archs'], mirror_fprint,
+        sign_fprint)
+    hookenv.status_set('active', 'Mirrorining configured')
 
 
-@when('static-website.available')
-def static_website_relation(apache):
-    domain = hookenv.unit_public_ip()
-    config = get_website_relation_config(domain)
-    apache.send_domain(config['domain'])
-    apache.send_site_config(config['site_config'])
-    apache.send_site_modules(config['site_modules'])
-    apache.send_ports(config['ports'])
-    apache.send_enabled()
+@when_not('config.set.mirror-uri', 'config.set.mirror-archs',
+          'config.set.mirror-gpg-key', 'config.set.sign-gpg-key')
+def config_not_set():
+    reprepro.disable_mirroring()
+    hookenv.status_set(
+        'blocked', 'Not all required configs set, mirroring is disabled')
+
+
+def configure_static_serve():
+    '''Configure the static file serve.'''
+    vhost_config = utils.get_virtualhost_config()
+    configure_site(
+        'archive-auth-mirror', 'nginx-static.j2', **vhost_config)

--- a/templates/nginx-static.j2
+++ b/templates/nginx-static.j2
@@ -1,0 +1,13 @@
+server {
+    server_name {{ domain }};
+
+    listen {{ port }};
+    listen [::]:{{ port }};
+
+    root {{ document_root }};
+
+    location / {
+        autoindex on;
+    }
+}
+

--- a/tests/10-deploy
+++ b/tests/10-deploy
@@ -10,19 +10,14 @@ import amulet
 class TestCharm(unittest.TestCase):
     def setUp(self):
         self.d = amulet.Deployment(series='xenial')
-
-        self.d.add('apache2')
         self.d.add('archive-auth-mirror')
-        self.d.relate(
-            'archive-auth-mirror:static-website', 'apache2:apache-website')
-
         self.d.setup(timeout=900)
         self.d.sentry.wait()
 
         self.unit = self.d.sentry['archive-auth-mirror'][0]
 
-    def test_website_relation(self):
-        """The apache-website configures the virtualhost for the static dir."""
+    def test_deploy(self):
+        """The service provides static file serving."""
         url = 'http://{}'.format(self.unit.info['public-address'])
         page = requests.get(url)
         self.assertIn('Index of /', page.text)

--- a/unit_tests/test_reprepro.py
+++ b/unit_tests/test_reprepro.py
@@ -87,7 +87,7 @@ class DisableMirroringTest(CharmTest):
 class SplitRepositoryUriTest(unittest.TestCase):
 
     def test_uri(self):
-        """split_repo_uri splits the repository URI into tokens."""
+        """split_repository_uri splits the repository URI into tokens."""
         tokens = split_repository_uri(
             'https://user:pass@example.com/ubuntu xenial main universe')
         self.assertEqual(

--- a/unit_tests/test_utils.py
+++ b/unit_tests/test_utils.py
@@ -1,4 +1,3 @@
-import textwrap
 import unittest
 from pathlib import Path
 
@@ -15,7 +14,7 @@ from charmtest import CharmTest
 from charms.archive_auth_mirror.utils import (
     get_paths,
     get_virtualhost_name,
-    get_website_relation_config,
+    get_virtualhost_config,
     install_resources,
 )
 
@@ -51,28 +50,15 @@ class GetVirtualhostNameTest(unittest.TestCase):
         self.assertEqual('example.com', get_virtualhost_name(hookenv=hookenv))
 
 
-class GetWebsiteRelationConfigTest(unittest.TestCase):
+class GetVirtualhostConfigTest(CharmTest):
 
-    def test_config(self):
-        """get_website_relation_config returns the relation configuration."""
-        config = get_website_relation_config('host.example.com')
-
-        expected_site_config = textwrap.dedent("""
-        <VirtualHost host.example.com:80>
-          DocumentRoot "/srv/archive-auth-mirror/static"
-
-          <Location />
-            Require all granted
-            Options +Indexes
-          </Location>
-        </VirtualHost>
-        """)
+    def test_virtualhost_config(self):
+        """get_virtualhost_config returns the config for the virtualhost."""
+        hookenv = FakeHookEnv()
+        config = get_virtualhost_config(hookenv=hookenv)
         self.assertEqual(
-            {'domain': 'host.example.com',
-             'enabled': True,
-             'site_config': expected_site_config,
-             'site_modules': ['autoindex'],
-             'ports': [80]},
+            {'domain': '1.2.3.4',
+             'document_root': '/srv/archive-auth-mirror/static'},
             config)
 
 


### PR DESCRIPTION
This uses the nginx charm layer instead of relating to configure apache via relation.

With this change the charm is no longer a subordinate one, but installs and configures nginx directly.
The logic is simpler this way since there's no longer need to reset relation data on configuration changes, and there's one less service involved.