### PR TITLE
Add dist entry to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: trusty
 sudo: required
 python:
   - "3.5"


### PR DESCRIPTION
Travis is still running on Precise (!) by default - see https://github.com/travis-ci/travis-ci/issues/5821 for more info, but for now use Trusty instead. https://docs.travis-ci.com/user/trusty-ci-environment