### PR TITLE
Configure cron to run the mirroring script

### DIFF
--- a/lib/charms/archive_auth_mirror/utils.py
+++ b/lib/charms/archive_auth_mirror/utils.py
@@ -52,8 +52,12 @@ def get_virtualhost_config(hookenv=hookenv):
         'basic_auth_file': str(paths['basic-auth'])}
 
 
-def install_resources(base_dir=None):
+def install_resources(base_dir=None, cron_dir=None):
     """Create tree structure and copy resources from the charm."""
+    if cron_dir is None:
+        cron_dir = '/etc/cron.d'
+    cron_dir = Path(cron_dir)
+
     paths = get_paths(base_dir=base_dir)
     for name in ('bin', 'reprepro-conf', 'static'):
         host.mkdir(str(paths[name]), perms=0o755)
@@ -70,3 +74,6 @@ def install_resources(base_dir=None):
     for resource in ('mirror-archive', 'manage-user'):
         resource_path = os.path.join('resources', resource)
         shutil.copy(resource_path, str(paths['bin']))
+    # install crontab
+    crontab_file = cron_dir.joinpath('archive-auth-mirror')
+    shutil.copy('resources/crontab', str(crontab_file))

--- a/resources/crontab
+++ b/resources/crontab
@@ -1,0 +1,2 @@
+#  m h dom mon dow user  command
+*/15 *   *   *   * root  /srv/archive-auth-mirror/bin/mirror-archive

--- a/resources/mirror-archive
+++ b/resources/mirror-archive
@@ -4,20 +4,35 @@
 #
 
 BASEDIR="$(realpath $(dirname $0)/..)"
+SCRIPTNAME="$(basename $0)"
 
+CONFIG_FILE="$BASEDIR/config"
 REPO_DIR="$BASEDIR/static/ubuntu"
+
 # Variables used by reprepro
 export REPREPRO_BASE_DIR="$BASEDIR/reprepro"
 export REPREPRO_CONFIG_DIR="$REPREPRO_BASE_DIR/conf"
 export GNUPGHOME="$REPREPRO_BASE_DIR/.gnupg"
 
+
+log() {
+    logger -t "$SCRIPTNAME" -i "$@"
+}
+
 # Load the config file if present.
 #
 # currently, it must define the $SUITE variable
 #
-. "$BASEDIR/config" || exit
+if [ -f "$CONFIG_FILE" ]; then
+    . "$CONFIG_FILE"
+else
+    log "config file not found, mirroring disabled"
+    exit
+fi
 
 REPREPRO="reprepro --outdir $REPO_DIR"
 
+log "starting mirroring"
 $REPREPRO --show-percent update "$SUITE"
 $REPREPRO deleteunreferenced
+log "mirroring completed"


### PR DESCRIPTION
Add cron configuration to periodically run the mirroring script

This also adds some logging to the script itself, to report whether reprepro is run or not 