### PR TITLE
Pass the root path instead of base and cron dirs

### DIFF
--- a/unit_tests/test_reprepro.py
+++ b/unit_tests/test_reprepro.py
@@ -1,5 +1,6 @@
 import textwrap
 import unittest
+from pathlib import Path
 
 from charmtest import CharmTest
 
@@ -15,7 +16,7 @@ class ConfigureRepreproTest(CharmTest):
 
     def test_configuration_files(self):
         """configure_reprepro writes rerepro config files."""
-        paths = get_paths(base_dir=self.fakes.fs.root.path)
+        paths = get_paths(root_dir=Path(self.fakes.fs.root.path))
         uri = 'https://user:pass@example.com/ubuntu xenial main universe'
         configure_reprepro(
             uri, 'i386 amd64', 'ABABABAB', 'CDCDCDCD', get_paths=lambda: paths)
@@ -49,7 +50,7 @@ class DisableMirroringTest(CharmTest):
 
     def test_disable_mirroring(self):
         """disable_mirroring renames the script config file."""
-        paths = get_paths(base_dir=self.fakes.fs.root.path)
+        paths = get_paths(root_dir=Path(self.fakes.fs.root.path))
         uri = 'https://user:pass@example.com/ubuntu xenial main universe'
         configure_reprepro(
             uri, 'i386 amd64', 'ABABABAB', 'CDCDCDCD', get_paths=lambda: paths)
@@ -66,15 +67,15 @@ class DisableMirroringTest(CharmTest):
 
     def test_disable_not_enabled(self):
         """Disabling mirror when not configured is a no-op."""
-        paths = get_paths(base_dir=self.fakes.fs.root.path)
+        paths = get_paths(root_dir=Path(self.fakes.fs.root.path))
         config = paths['config']
         disable_mirroring(get_paths=lambda: paths)
         self.assertFalse(config.exists())
         self.assertFalse(config.with_suffix('.disabled').exists())
 
-    def test_disable_twice_(self):
+    def test_disable_twice(self):
         """disable_mirroring can be called multiple times."""
-        paths = get_paths(base_dir=self.fakes.fs.root.path)
+        paths = get_paths(root_dir=Path(self.fakes.fs.root.path))
         config = paths['config']
         disable_mirroring(get_paths=lambda: paths)
         disable_mirroring(get_paths=lambda: paths)


### PR DESCRIPTION
Trivial change to pass the root dir to get_path (used only in tests), instead of multiple paths