### PR TITLE
Add a script to push and release charm to edge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CHARM_NAME = archive-auth-mirror
 CHARM_SERIES = xenial
 CHARM_OUTPUT = build/charm-output
 RENDERED_CHARM_DIR = $(CHARM_OUTPUT)/$(CHARM_SERIES)/$(CHARM_NAME)
-RENDERED_CHARM_URI = cs:~landscape/$(CHARM_NAME)
+CHARM_URI = cs:~landscape/$(CHARM_NAME)
 
 
 .PHONY: help
@@ -10,14 +10,14 @@ help: ## Print help about available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: charm-build
-charm-build:  ## Build the charm
+charm-build: REV_HASH = $(shell git rev-parse HEAD)
+charm-build: ## Build the charm
 	rm -rf $(CHARM_OUTPUT)
 	charm build -s $(CHARM_SERIES) -o $(CHARM_OUTPUT)
+	echo "commit-sha-1: $(REV_HASH)" > $(RENDERED_CHARM_DIR)/repo-info
 
 .PHONY: charm-push
-charm-push: charm-build ## Push the rendered charm to the charm store
-	echo -n "commit-sha-1: "  > $(RENDERED_CHARM_DIR)/repo-info
-	git rev-parse HEAD >> $(RENDERED_CHARM_DIR)/repo-info
-	charm push $(RENDERED_CHARM_DIR) $(RENDERED_CHARM_URI)
+charm-push: charm-build ## Push the charm to the store and release it in the edge channel
+	./release-charm $(RENDERED_CHARM_DIR) $(CHARM_URI)
 
 .DEFAULT_GOAL := help

--- a/release-charm
+++ b/release-charm
@@ -1,0 +1,35 @@
+#!/bin/bash -e
+
+if [ "$#" -lt 2 ]; then
+    echo "Usage $(basename $0) charm-dir charm-uri"
+    exit 1
+fi
+
+RENDERED_CHARM_DIR="$1"
+CHARM_URI="$2"
+
+GIT_UPSTREAM_REPO="git@github.com:CanonicalLtd/archive-auth-mirror"
+GIT_UPSTREAM_REMOTE="upstream"
+
+# push the charm to the store and grab the returned version
+OUT=$(mktemp)
+charm push $RENDERED_CHARM_DIR $CHARM_URI | tee $OUT
+PUSHED_CHARM="$(cat $OUT | sed -n 's/^url: //p')"
+PUSHED_CHARM_REV=${PUSHED_CHARM##*-}
+rm $OUT
+
+REV_HASH=$(awk '{ print $NF; }' "$RENDERED_CHARM_DIR"/repo-info)
+
+# publish the charm
+charm set $PUSHED_CHARM revision=$REV_HASH
+charm grant $PUSHED_CHARM --acl read --set everyone
+charm release $PUSHED_CHARM --channel=edge
+
+# tag the repo with the charm revision
+if ! git remote | grep -q $GIT_UPSTREAM_REMOTE; then
+    git remote add $GIT_UPSTREAM $GIT_UPSTREAM_REPO
+fi
+
+GIT_TAG=charm-r${PUSHED_CHARM_REV}
+git tag $GIT_TAG $REV_HASH
+git push $GIT_UPSTREAM_REMOTE $GIT_TAG


### PR DESCRIPTION
This adds a helper script to push and releae the charm to the store in the edge channel.

It makes the "make charm-push" target also 
 - publish the charm
 - make it publicly readable
 - tag the repo with the returned charm revision
 - add the commit hash to the charm metadata
