### PR TITLE
Support signature keys with passphrase

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -23,3 +23,7 @@ options:
     type: string
     description: "GPG key for signing the archive."
     default: ""
+  sign-gpg-passphrase:
+    type: string
+    description: "Passphrase for the sign-gpg-key."
+    default: ""

--- a/lib/charms/archive_auth_mirror/reprepro.py
+++ b/lib/charms/archive_auth_mirror/reprepro.py
@@ -6,14 +6,17 @@ from .utils import get_paths
 
 
 def configure_reprepro(mirror_uri, mirror_archs, mirror_key_fingerprint,
-                       sign_key_fingerprint, get_paths=get_paths):
+                       sign_key_fingerprint, sign_key_passphrase,
+                       get_paths=get_paths):
     """Create reprepro configuration files."""
     paths = get_paths()
     context = split_repository_uri(mirror_uri)
     context.update(
         {'archs': mirror_archs,
          'mirror_key': mirror_key_fingerprint,
-         'sign_key': sign_key_fingerprint})
+         'sign_key': sign_key_fingerprint,
+         'sign_script': paths['bin'] / 'reprepro-sign-helper'})
+
     # explicitly pass owner and group for tests, otherwise root would be used
     owner = group = getpass.getuser()
     render(
@@ -25,6 +28,9 @@ def configure_reprepro(mirror_uri, mirror_archs, mirror_key_fingerprint,
         context, owner=owner, group=group)
     render(
         'config.j2', str(paths['config']), context, owner=owner, group=group)
+    # save the sign passphrase for the signing helper script
+    with paths['sign-passphrase'].open('w') as fh:
+        fh.write(sign_key_passphrase)
 
 
 def disable_mirroring(get_paths=get_paths):

--- a/reactive/archive_auth_mirror.py
+++ b/reactive/archive_auth_mirror.py
@@ -41,10 +41,10 @@ def config_set():
     # configure mirroring
     mirror_fprint, sign_fprint = gpg.import_gpg_keys(
         config['mirror-gpg-key'], config['sign-gpg-key'])
-    sign_gpg_passphtase = config.get('sign-gpg-passphrase', '').strip()
+    sign_gpg_passphrase = config.get('sign-gpg-passphrase', '').strip()
     reprepro.configure_reprepro(
         config['mirror-uri'].strip(), config['mirror-archs'].strip(),
-        mirror_fprint, sign_fprint, sign_gpg_passphtase)
+        mirror_fprint, sign_fprint, sign_gpg_passphrase)
     hookenv.status_set('active', 'Mirroring configured')
 
 

--- a/reactive/archive_auth_mirror.py
+++ b/reactive/archive_auth_mirror.py
@@ -32,18 +32,19 @@ def config_mirror_uri_changed():
     configure_static_serve()
 
 
-@when(charm_state('installed'), 'config.set.mirror-uri',
-      'config.set.mirror-archs', 'config.set.mirror-gpg-key',
-      'config.set.sign-gpg-key')
+@when(charm_state('installed'), 'config.changed')
 def config_set():
     config = hookenv.config()
+    if not utils.have_required_config(config):
+        return
 
     # configure mirroring
     mirror_fprint, sign_fprint = gpg.import_gpg_keys(
         config['mirror-gpg-key'], config['sign-gpg-key'])
+    sign_gpg_passphtase = config.get('sign-gpg-passphrase', '').strip()
     reprepro.configure_reprepro(
-        config['mirror-uri'], config['mirror-archs'], mirror_fprint,
-        sign_fprint)
+        config['mirror-uri'].strip(), config['mirror-archs'].strip(),
+        mirror_fprint, sign_fprint, sign_gpg_passphtase)
     hookenv.status_set('active', 'Mirroring configured')
 
 

--- a/resources/reprepro-sign-helper
+++ b/resources/reprepro-sign-helper
@@ -1,0 +1,38 @@
+#!/bin/bash -e
+#
+# Helper to sign files for reprepro
+#
+
+BASEDIR="$(realpath $(dirname $0)/..)"
+CONFIG_FILE="$BASEDIR/config"
+PASSPHRASE_FILE="$BASEDIR/sign-passphrase"
+
+
+# From reprepro(1):
+#
+# It gets three command line arguments: The filename to sign, an empty argument
+# or the filename to create with an inline signature (i.e. InRelease) and an
+# empty argument or the filename to create an detached signature
+# (i.e. Release.gpg).  The script may generate no Release.gpg file if it choses
+# to (then the repository will look like unsigned for older clients), but
+# generating empty files is not allowed.  Reprepro waits for the script to
+# finish and will abort the exporting of the distribution this signing is part
+# of unless the scripts returns normally with exit code 0.
+#
+UNSIGNED_FILE="$1"
+INLINE_SIGN_FILE="$2"
+DETACH_SIGN_FILE="$3"
+
+
+# The config file must define the $SIGN_KEY_ID variable
+. "$CONFIG_FILE"
+
+GPG="gpg --no-use-agent --batch --passphrase-file $PASSPHRASE_FILE -u $SIGN_KEY_ID"
+
+if [ "$INLINE_SIGN_FILE" ]; then
+    $GPG -o "$INLINE_SIGN_FILE" --clearsign -a "$UNSIGNED_FILE"
+fi
+
+if [ "$DETACH_SIGN_FILE" ]; then
+    $GPG -o "$DETACH_SIGN_FILE" --detach-sig -a "$UNSIGNED_FILE"
+fi

--- a/templates/config.j2
+++ b/templates/config.j2
@@ -1,2 +1,3 @@
 SUITE={{ suite }}
+SIGN_KEY_ID={{ sign_key }}
 

--- a/templates/reprepro-distributions.j2
+++ b/templates/reprepro-distributions.j2
@@ -2,6 +2,6 @@ Codename: {{ suite }}
 Label: {{ suite }} archive
 Components: {{ components }}
 Architectures: {{ archs }}
-SignWith: {{ sign_key }}
+SignWith: ! {{ sign_script }}
 Update: update-repo
 

--- a/unit_tests/test_reprepro.py
+++ b/unit_tests/test_reprepro.py
@@ -19,7 +19,8 @@ class ConfigureRepreproTest(CharmTest):
         paths = get_paths(root_dir=Path(self.fakes.fs.root.path))
         uri = 'https://user:pass@example.com/ubuntu xenial main universe'
         configure_reprepro(
-            uri, 'i386 amd64', 'ABABABAB', 'CDCDCDCD', get_paths=lambda: paths)
+            uri, 'i386 amd64', 'ABABABAB', 'CDCDCDCD', 'very secret',
+            get_paths=lambda: paths)
         self.assertEqual(
             textwrap.dedent(
                 '''\
@@ -27,9 +28,9 @@ class ConfigureRepreproTest(CharmTest):
                 Label: xenial archive
                 Components: main universe
                 Architectures: i386 amd64
-                SignWith: CDCDCDCD
+                SignWith: ! {}/reprepro-sign-helper
                 Update: update-repo
-                '''),
+                '''.format(paths['bin'])),
             (paths['reprepro-conf'] / 'distributions').read_text())
         self.assertEqual(
             textwrap.dedent(
@@ -43,7 +44,12 @@ class ConfigureRepreproTest(CharmTest):
                 '''),
             (paths['reprepro-conf'] / 'updates').read_text())
         self.assertEqual(
-            'SUITE=xenial\n', paths['config'].read_text())
+            textwrap.dedent(
+                '''\
+                SUITE=xenial
+                SIGN_KEY_ID=CDCDCDCD
+                '''),
+            paths['config'].read_text())
 
 
 class DisableMirroringTest(CharmTest):
@@ -53,7 +59,8 @@ class DisableMirroringTest(CharmTest):
         paths = get_paths(root_dir=Path(self.fakes.fs.root.path))
         uri = 'https://user:pass@example.com/ubuntu xenial main universe'
         configure_reprepro(
-            uri, 'i386 amd64', 'ABABABAB', 'CDCDCDCD', get_paths=lambda: paths)
+            uri, 'i386 amd64', 'ABABABAB', 'CDCDCDCD', 'very secret',
+            get_paths=lambda: paths)
 
         config = paths['config']
         self.assertTrue(config.exists())


### PR DESCRIPTION
This adds support for a passphrase for the GPG key used to sign the repository (and the charm option to set it).

Reprepro is now configured to call a script to sign lists, which calls gpg with the configured signature key.
If the passphrase is not used, it can be left empty.

I plan to take a look at migrating both the mirroring and gpg wrapper script to python in a followup PR, since they share a bit of setup code, which would be nice to unittest.