### PR TITLE
More cleanups

### DIFF
--- a/lib/archive_auth_mirror/scripts/manage_user.py
+++ b/lib/archive_auth_mirror/scripts/manage_user.py
@@ -1,0 +1,62 @@
+"""Manage users for repository access through basic authentication."""
+
+import subprocess
+import argparse
+
+from ..utils import get_paths
+
+
+def add_user(auth_file, user, passwd):
+    """Add a user."""
+    subprocess.run(
+        ['htpasswd', '-i', str(auth_file), user],
+        input=passwd.encode('utf8'), stderr=subprocess.DEVNULL,
+        check=True)
+
+
+def list_users(auth_file):
+    """List existing users."""
+    if not auth_file.exists():
+        return []
+    with auth_file.open() as fh:
+        return [line.split(':')[0] for line in fh]
+
+
+def remove_user(auth_file, user):
+    """Remove a user."""
+    subprocess.check_call(
+        ['htpasswd', '-D', str(auth_file), user],
+        stderr=subprocess.DEVNULL)
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    action = subparsers = parser.add_subparsers(
+        dest='action', help='action to perform')
+    action.required = True
+
+    add_action = subparsers.add_parser(
+        'add',
+        help='add a user. If the user exists, their password is updated')
+    add_action.add_argument('user', help='the username to add')
+    add_action.add_argument('password', help='the password for the user')
+
+    subparsers.add_parser('list', help='list users')
+
+    remove_action = subparsers.add_parser('remove', help='remove a user')
+    remove_action.add_argument('user', help='the user to remove')
+
+    return parser
+
+
+def main():
+    args = get_parser().parse_args()
+    auth_file = get_paths()['basic-auth']
+
+    if args.action == 'add':
+        add_user(auth_file, args.user, args.password)
+    elif args.action == 'remove':
+        remove_user(auth_file, args.user)
+    elif args.action == 'list':
+        for user in list_users(auth_file):
+            print(user)

--- a/resources/manage-user
+++ b/resources/manage-user
@@ -1,71 +1,13 @@
 #!/usr/bin/env python3
+#
+# Manage users for repository access through basic authentication.
+#
 
-"""Manage users for repository access through basic authentication."""
+import sys
+from os import path
 
-from pathlib import Path
-import subprocess
-import argparse
+sys.path.append(path.join(path.dirname(__file__), 'lib'))
 
+from archive_auth_mirror.scripts import manage_user
 
-AUTH_FILE = Path(__file__).parent.parent.absolute() / 'basic-auth'
-
-
-class UnknownUser(Exception):
-
-    def __init__(self, user):
-        super().__init__('Unknown user "{}"'.format(user))
-
-
-def get_parser():
-    parser = argparse.ArgumentParser(description=__doc__)
-    action = subparsers = parser.add_subparsers(
-        dest='action', help='action to perform')
-    action.required = True
-
-    add_action = subparsers.add_parser(
-        'add',
-        help='add a user. If the user exists, their password is updated')
-    add_action.add_argument('user', help='the username to add')
-    add_action.add_argument('password', help='the password for the user')
-
-    subparsers.add_parser('list', help='list users')
-
-    remove_action = subparsers.add_parser('remove', help='remove a user')
-    remove_action.add_argument('user', help='the user to remove')
-
-    return parser
-
-
-def add_user(auth_file, user, passwd):
-    """Add a user."""
-    subprocess.run(
-        ['htpasswd', '-i', str(auth_file), user],
-        input=passwd.encode('utf8'), stderr=subprocess.DEVNULL,
-        check=True)
-
-
-def list_users(auth_file):
-    """List existing users."""
-    if not auth_file.exists():
-        return []
-    with auth_file.open() as fh:
-        return [line.split(':')[0] for line in fh]
-
-
-def remove_user(auth_file, user):
-    """Remove a user"""
-    subprocess.check_call(
-        ['htpasswd', '-D', str(auth_file), user],
-        stderr=subprocess.DEVNULL)
-
-
-if __name__ == '__main__':
-    args = get_parser().parse_args()
-
-    if args.action == 'add':
-        add_user(AUTH_FILE, args.user, args.password)
-    elif args.action == 'remove':
-        remove_user(AUTH_FILE, args.user)
-    elif args.action == 'list':
-        for user in list_users(AUTH_FILE):
-            print(user)
+manage_user.main()

--- a/unit_tests/test_manage_user.py
+++ b/unit_tests/test_manage_user.py
@@ -2,12 +2,11 @@ from pathlib import Path
 
 from fixtures import TestWithFixtures, TempDir
 
-from importlib.machinery import SourceFileLoader
-
-
-# manually import the script since it's not in a module
-manage_user = SourceFileLoader(
-    'manage_user', "resources/manage-user").load_module()
+from archive_auth_mirror.scripts.manage_user import (
+    add_user,
+    remove_user,
+    list_users,
+)
 
 
 class ManageUserTest(TestWithFixtures):
@@ -20,26 +19,26 @@ class ManageUserTest(TestWithFixtures):
 
     def test_add_user(self):
         """add_user adds the user with the specified password."""
-        manage_user.add_user(self.auth_file, 'user1', 'pass1')
-        manage_user.add_user(self.auth_file, 'user2', 'pass2')
+        add_user(self.auth_file, 'user1', 'pass1')
+        add_user(self.auth_file, 'user2', 'pass2')
         self.assertIn('user1:', self.auth_file.read_text())
         self.assertIn('user2:', self.auth_file.read_text())
 
     def test_list_users(self):
         """list_users lists existing users."""
-        manage_user.add_user(self.auth_file, 'user1', 'pass1')
-        manage_user.add_user(self.auth_file, 'user2', 'pass2')
-        users = manage_user.list_users(self.auth_file)
+        add_user(self.auth_file, 'user1', 'pass1')
+        add_user(self.auth_file, 'user2', 'pass2')
+        users = list_users(self.auth_file)
         self.assertEqual(['user1', 'user2'], users)
 
     def test_list_users_no_file(self):
         """list_users returns an empty list if the file is not present."""
-        self.assertEqual([], manage_user.list_users(self.auth_file))
+        self.assertEqual([], list_users(self.auth_file))
 
     def test_remove_user(self):
         """remove_user removes a user."""
-        manage_user.add_user(self.auth_file, 'user1', 'pass1')
-        manage_user.add_user(self.auth_file, 'user2', 'pass2')
-        manage_user.remove_user(self.auth_file, 'user1')
+        add_user(self.auth_file, 'user1', 'pass1')
+        add_user(self.auth_file, 'user2', 'pass2')
+        remove_user(self.auth_file, 'user1')
         self.assertNotIn('user1', self.auth_file.read_text())
         self.assertIn('user2', self.auth_file.read_text())

--- a/unit_tests/test_setup.py
+++ b/unit_tests/test_setup.py
@@ -83,7 +83,7 @@ class InstallResourcesTests(CharmTest):
             FileContains(matcher=Contains("import mirror_archive")))
         self.assertThat(
             self.root_dir.join('srv/archive-auth-mirror/bin/manage-user'),
-            FileContains(matcher=Contains("htpasswd")))
+            FileContains(matcher=Contains("import manage_user")))
         sign_script_path = 'srv/archive-auth-mirror/bin/reprepro-sign-helper'
         self.assertThat(
             self.root_dir.join(sign_script_path),


### PR DESCRIPTION
Trivial change to move the logic for the manage-user script under lib.arcrhive_auth_mirror.scripts, and have the script file just call main(), in line with other scripts.