### PR TITLE
Only run the job on the leader unit

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -1,5 +1,6 @@
 includes:
   - 'layer:basic'
+  - 'layer:leadership'
   - 'layer:nginx'
   - 'layer:nagios'
 repo: https://github.com/CanonicalLtd/archive-auth-mirror

--- a/lib/archive_auth_mirror/cron.py
+++ b/lib/archive_auth_mirror/cron.py
@@ -1,0 +1,31 @@
+"""Cron job configuration."""
+
+import textwrap
+
+from .utils import get_paths
+
+
+CRONTAB_TEMPLATE = textwrap.dedent(
+    '''
+    #  m h dom mon dow user  command
+    */15 *   *   *   * root  {paths[bin]}/mirror-archive
+    ''')
+
+
+def install_crontab(paths=None):
+    """Install the crontab file to periodically run the job."""
+    if paths is None:
+        paths = get_paths()
+
+    with paths['cron'].open('w') as fh:
+        fh.write(CRONTAB_TEMPLATE.format(paths=paths))
+
+
+def remove_crontab(paths=None):
+    """Remove the crontab file for the job."""
+    if paths is None:
+        paths = get_paths()
+
+    cron_file = paths['cron']
+    if cron_file.exists():
+        cron_file.unlink()

--- a/lib/charms/archive_auth_mirror/setup.py
+++ b/lib/charms/archive_auth_mirror/setup.py
@@ -50,8 +50,6 @@ def install_resources(root_dir=None):
     for resource in SCRIPTS:
         resource_path = os.path.join('resources', resource)
         shutil.copy(resource_path, str(paths['bin']))
-    # install crontab
-    shutil.copy('resources/crontab', str(paths['cron']))
     # symlink the lib libary to make it available to scripts too
     (paths['bin'] / 'lib').symlink_to(Path.cwd() / 'lib')
 

--- a/reactive/archive_auth_mirror.py
+++ b/reactive/archive_auth_mirror.py
@@ -1,6 +1,6 @@
 from charmhelpers.core import hookenv
 
-from charms.reactive import when, when_not, set_state
+from charms.reactive import when, when_not, set_state, remove_state
 
 from charms.layer.nginx import configure_site
 
@@ -58,14 +58,18 @@ def config_not_set():
         'blocked', 'Not all required configs set, mirroring is disabled')
 
 
+@when_not(charm_state('job.enabled'))
 @when('leadership.is_leader')
 def install_cron():
     cron.install_crontab()
+    set_state(charm_state('job.enabled'))
 
 
 @when_not('leadership.is_leader')
+@when(charm_state('job.enabled'))
 def remove_cron():
     cron.remove_crontab()
+    remove_state(charm_state('job.enabled'))
 
 
 def _configure_static_serve():

--- a/reactive/archive_auth_mirror.py
+++ b/reactive/archive_auth_mirror.py
@@ -5,7 +5,7 @@ from charms.reactive import when, when_not, set_state
 from charms.layer.nginx import configure_site
 
 from charms.archive_auth_mirror import reprepro, setup
-from archive_auth_mirror import gpg
+from archive_auth_mirror import gpg, cron
 
 
 def charm_state(state):
@@ -21,7 +21,7 @@ def install():
 
 @when(charm_state('installed'), 'nginx.available')
 def configure_webapp():
-    configure_static_serve()
+    _configure_static_serve()
 
 
 @when(charm_state('installed'), 'nginx.available', 'website.available')
@@ -31,7 +31,7 @@ def configure_website(website):
 
 @when(charm_state('installed'), 'config.changed.mirror-uri')
 def config_mirror_uri_changed():
-    configure_static_serve()
+    _configure_static_serve()
 
 
 @when(charm_state('installed'), 'config.changed')
@@ -58,7 +58,17 @@ def config_not_set():
         'blocked', 'Not all required configs set, mirroring is disabled')
 
 
-def configure_static_serve():
+@when('leadership.is_leader')
+def install_cron():
+    cron.install_crontab()
+
+
+@when_not('leadership.is_leader')
+def remove_cron():
+    cron.remove_crontab()
+
+
+def _configure_static_serve():
     """Configure the static file serve."""
     vhost_config = setup.get_virtualhost_config()
     configure_site(

--- a/resources/crontab
+++ b/resources/crontab
@@ -1,2 +1,0 @@
-#  m h dom mon dow user  command
-*/15 *   *   *   * root  /srv/archive-auth-mirror/bin/mirror-archive

--- a/unit_tests/test_cron.py
+++ b/unit_tests/test_cron.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+from fixtures import TestWithFixtures, TempDir
+
+from archive_auth_mirror.utils import get_paths
+from archive_auth_mirror.cron import install_crontab, remove_crontab
+
+
+class InstallCrontabTest(TestWithFixtures):
+
+    def test_install_crontab(self):
+        """install_crontab creates a crontab file"""
+        root_dir = Path(self.useFixture(TempDir()).path)
+        (root_dir / 'etc/cron.d').mkdir(parents=True)
+        paths = get_paths(root_dir=root_dir)
+        install_crontab(paths=paths)
+
+        with paths['cron'].open() as fh:
+            content = fh.read()
+
+        script = paths['bin'] / 'mirror-archive'
+        self.assertIn(str(script), content)
+
+
+class RemoveCrontabTest(TestWithFixtures):
+
+    def setUp(self):
+        super().setUp()
+        self.root_dir = Path(self.useFixture(TempDir()).path)
+        (self.root_dir / 'etc/cron.d').mkdir(parents=True)
+        self.paths = get_paths(root_dir=self.root_dir)
+
+    def test_remove_crontab(self):
+        """remove_crontab removes the crontab file."""
+        install_crontab(paths=self.paths)
+        remove_crontab(paths=self.paths)
+        self.assertFalse(self.paths['cron'].exists())
+
+    def test_remove_crontab_not_existet(self):
+        """If the crontab file doesn't exist, remove_crontab no-ops."""
+        self.assertFalse(self.paths['cron'].exists())
+        remove_crontab(paths=self.paths)
+        self.assertFalse(self.paths['cron'].exists())

--- a/unit_tests/test_cron.py
+++ b/unit_tests/test_cron.py
@@ -36,7 +36,7 @@ class RemoveCrontabTest(TestWithFixtures):
         remove_crontab(paths=self.paths)
         self.assertFalse(self.paths['cron'].exists())
 
-    def test_remove_crontab_not_existet(self):
+    def test_remove_crontab_not_existent(self):
         """If the crontab file doesn't exist, remove_crontab no-ops."""
         self.assertFalse(self.paths['cron'].exists())
         remove_crontab(paths=self.paths)

--- a/unit_tests/test_setup.py
+++ b/unit_tests/test_setup.py
@@ -53,7 +53,6 @@ class InstallResourcesTests(CharmTest):
     def setUp(self):
         super().setUp()
         self.root_dir = self.useFixture(TempDir())
-        os.makedirs(self.root_dir.join('etc/cron.d'))
 
         patcher_chown = mock.patch('os.chown')
         patcher_chown.start()
@@ -88,10 +87,6 @@ class InstallResourcesTests(CharmTest):
         self.assertThat(
             self.root_dir.join(sign_script_path),
             FileContains(matcher=Contains("import reprepro_sign_helper")))
-        script_path = '/srv/archive-auth-mirror/bin/mirror-archive'
-        self.assertThat(
-            self.root_dir.join('etc/cron.d/archive-auth-mirror'),
-            FileContains(matcher=Contains(script_path)))
         auth_file = self.root_dir.join('srv/archive-auth-mirror/basic-auth')
         self.assertEqual(0o100640, os.stat(auth_file).st_mode)
 


### PR DESCRIPTION
This creates/removes the crontab for the mirror job on leadership changes, so that it only runs on the leader unit.

To test:
 - deploy the service with 2 units
 - `juju run --application archive-auth-mirror 'ls -l /etc/cron.d'`

the archive-auth-mirror file is only on the leader.
You can switch leader by stopping the jujud-unit-archive-auth-mirror-* job on the leader unit.