### PR TITLE
Use the charm virtualenv for running scripts

### DIFF
--- a/lib/charms/archive_auth_mirror/setup.py
+++ b/lib/charms/archive_auth_mirror/setup.py
@@ -57,9 +57,7 @@ def create_script_file(name, bindir):
     context = {
         'interpreter': Path.cwd().parent / '.venv/bin/python3',
         'script_module': name.replace('-', '_')}
-    # explicitly pass owner and group for tests, otherwise root would be used
-    render(
-        'script.j2', str(bindir / name), context, perms=0o755)
+    render('script.j2', str(bindir / name), context, perms=0o755)
 
 
 def have_required_config(config):

--- a/lib/charms/archive_auth_mirror/setup.py
+++ b/lib/charms/archive_auth_mirror/setup.py
@@ -1,4 +1,3 @@
-import getpass
 from pathlib import Path
 
 from charmhelpers.core import hookenv, host
@@ -59,10 +58,8 @@ def create_script_file(name, bindir):
         'interpreter': Path.cwd().parent / '.venv/bin/python3',
         'script_module': name.replace('-', '_')}
     # explicitly pass owner and group for tests, otherwise root would be used
-    owner = group = getpass.getuser()
     render(
-        'script.j2', str(bindir / name), context, owner=owner, group=group,
-        perms=0o755)
+        'script.j2', str(bindir / name), context, perms=0o755)
 
 
 def have_required_config(config):

--- a/lib/charms/archive_auth_mirror/setup.py
+++ b/lib/charms/archive_auth_mirror/setup.py
@@ -1,8 +1,8 @@
-import os
-import shutil
+import getpass
 from pathlib import Path
 
 from charmhelpers.core import hookenv, host
+from charmhelpers.core.templating import render
 
 from archive_auth_mirror.utils import get_paths
 
@@ -46,12 +46,23 @@ def install_resources(root_dir=None):
     # create an empty sign passphrase file, only readable by root
     host.write_file(str(paths['sign-passphrase']), b'', perms=0o600)
 
-    # copy scripts
-    for resource in SCRIPTS:
-        resource_path = os.path.join('resources', resource)
-        shutil.copy(resource_path, str(paths['bin']))
+    # install scripts
+    for script in SCRIPTS:
+        create_script_file(script, paths['bin'])
     # symlink the lib libary to make it available to scripts too
     (paths['bin'] / 'lib').symlink_to(Path.cwd() / 'lib')
+
+
+def create_script_file(name, bindir):
+    """Write a python script file from the template."""
+    context = {
+        'interpreter': Path.cwd().parent / '.venv/bin/python3',
+        'script_module': name.replace('-', '_')}
+    # explicitly pass owner and group for tests, otherwise root would be used
+    owner = group = getpass.getuser()
+    render(
+        'script.j2', str(bindir / name), context, owner=owner, group=group,
+        perms=0o755)
 
 
 def have_required_config(config):

--- a/templates/script.j2
+++ b/templates/script.j2
@@ -1,0 +1,11 @@
+#!{{ interpreter }}
+
+import sys
+from os import path
+
+sys.path.append(path.join(path.dirname(__file__), 'lib'))
+
+from archive_auth_mirror.scripts import {{ script_module }}
+
+{{ script_module }}.main()
+

--- a/unit_tests/test_setup.py
+++ b/unit_tests/test_setup.py
@@ -2,8 +2,6 @@ from unittest import TestCase, mock
 import os
 from pathlib import Path
 
-from fixtures import TempDir
-
 from testtools.matchers import (
     FileContains,
     DirContains,
@@ -16,6 +14,7 @@ from charms.archive_auth_mirror.setup import (
     get_virtualhost_name,
     get_virtualhost_config,
     install_resources,
+    create_script_file,
     have_required_config,
 )
 
@@ -52,11 +51,16 @@ class InstallResourcesTests(CharmTest):
 
     def setUp(self):
         super().setUp()
-        self.root_dir = self.useFixture(TempDir())
+        self.root_dir = self.fakes.fs.root
+        os.makedirs(self.root_dir.join('etc/cron.d'))
 
         patcher_chown = mock.patch('os.chown')
         patcher_chown.start()
         self.addCleanup(patcher_chown.stop)
+
+        patcher_pwnam = mock.patch('pwd.getpwnam')
+        mock_pwnam = patcher_pwnam.start()
+        mock_pwnam.return_value = mock.MagicMock(pw_uid=456)
 
         patcher_grnam = mock.patch('grp.getgrnam')
         mock_grnam = patcher_grnam.start()
@@ -94,7 +98,23 @@ class InstallResourcesTests(CharmTest):
         """The basic-auth file is group-owned by www-data."""
         install_resources(root_dir=Path(self.root_dir.path))
         # the file ownership is changed to the gid for www-data
-        self.mock_fchown.assert_called_with(mock.ANY, 0, 123)
+        self.mock_fchown.assert_called_with(mock.ANY, 456, 123)
+
+
+class CreateScriptFileTest(CharmTest):
+
+    def test_crate_script_file(self):
+        """create_script_file renders a python script file."""
+        bindir = Path(self.fakes.fs.root.path)
+        create_script_file('foo', bindir)
+        script = bindir / 'foo'
+        content = script.read_text()
+
+        shebang = '#!{}/.venv/bin/python3\n'.format(Path.cwd().parent)
+        self.assertTrue(content.startswith(shebang))
+        self.assertIn('from archive_auth_mirror.scripts import foo', content)
+        self.assertIn('foo.main()', content)
+        self.assertEqual(0o100755, script.stat().st_mode)
 
 
 class HaveRequiredConfigsTest(TestCase):


### PR DESCRIPTION
Generate python scripts from a template, and use the python interpreter from the charm.

Since the charm and the service scripts share code, they should use the same set of packages.