### PR TITLE
Add rsync_multi function

### DIFF
--- a/lib/archive_auth_mirror/rsync.py
+++ b/lib/archive_auth_mirror/rsync.py
@@ -15,8 +15,23 @@ def rsync(path, host, delete=False):
 
     """
     path = str(path.absolute())
-    command = ['rsync', '-a']
+    command = ['/usr/bin/rsync', '-a']
     if delete:
         command.append('--delete')
     command.extend([path, '{}:{}'.format(host, path)])
-    subprocess.check_call(command)
+    subprocess.check_output(command)
+
+
+def rsync_multi(path, hosts, logger, delete=False):
+    """Copy a filesystem tree using rsync to multiple hosts.
+
+    If a call to rsync to a host fails, the error is logged via the provided
+    logger and the next host is attempted.
+
+    """
+    for host in hosts:
+        try:
+            rsync(path, host, delete=delete)
+        except subprocess.CalledProcessError as error:
+            logger.error(
+                'rsync to {} failed: {}'.format(host, error.output))

--- a/unit_tests/test_rsync.py
+++ b/unit_tests/test_rsync.py
@@ -1,21 +1,60 @@
 from pathlib import Path
+import logging
+from subprocess import CalledProcessError
 from unittest import TestCase, mock
 
-from archive_auth_mirror.rsync import rsync
+from fixtures import TestWithFixtures, LoggerFixture
+
+from archive_auth_mirror.rsync import rsync, rsync_multi
 
 
 class RsyncTest(TestCase):
 
-    @mock.patch('subprocess.check_call')
-    def test_rsync(self, mock_check_call):
+    @mock.patch('subprocess.check_output')
+    def test_rsync(self, mock_check_output):
         """The rsync copies a filesytem tree using rsync."""
         rsync(Path('/foo/bar'), '1.2.3.4')
-        mock_check_call.assert_called_with(
-            ['rsync', '-a', '/foo/bar', '1.2.3.4:/foo/bar'])
+        mock_check_output.assert_called_with(
+            ['/usr/bin/rsync', '-a', '/foo/bar', '1.2.3.4:/foo/bar'])
 
-    @mock.patch('subprocess.check_call')
-    def test_rsync_delete(self, mock_check_call):
+    @mock.patch('subprocess.check_output')
+    def test_rsync_delete(self, mock_check_output):
         """If the delete flag is True, the --delete option is passed."""
         rsync(Path('/foo/bar'), '1.2.3.4', delete=True)
-        mock_check_call.assert_called_with(
-            ['rsync', '-a', '--delete', '/foo/bar', '1.2.3.4:/foo/bar'])
+        mock_check_output.assert_called_with(
+            ['/usr/bin/rsync', '-a', '--delete', '/foo/bar',
+             '1.2.3.4:/foo/bar'])
+
+
+class RsyncMultiTest(TestWithFixtures):
+
+    def setUp(self):
+        super().setUp()
+        self.logger = self.useFixture(LoggerFixture())
+
+    @mock.patch('subprocess.check_output')
+    def test_each_host(self, mock_check_output):
+        """The rsync call is performed for each host."""
+        rsync_multi(Path('/foo/bar'), ['1.2.3.4', '5.6.7.8'], self.logger)
+        mock_check_output.assert_has_calls(
+            [mock.call(
+                ['/usr/bin/rsync', '-a', '/foo/bar', '1.2.3.4:/foo/bar']),
+             mock.call(
+                 ['/usr/bin/rsync', '-a', '/foo/bar', '5.6.7.8:/foo/bar'])])
+
+    @mock.patch('subprocess.check_output')
+    def test_log_failures(self, mock_check_output):
+        """If copy to a host fails, it's logged."""
+
+        def check_output(cmd):
+            if cmd[-1].startswith('1.2.3.4:'):
+                raise CalledProcessError(1, cmd, output='something failed')
+
+        mock_check_output.side_effect = check_output
+        rsync_multi(
+            Path('/foo/bar'), ['1.2.3.4', '5.6.7.8'], logging.getLogger())
+        self.assertEqual(
+            'rsync to 1.2.3.4 failed: something failed\n', self.logger.output)
+        # rsync to the second host is exectuted too
+        mock_check_output.assert_any_call(
+            ['/usr/bin/rsync', '-a', '/foo/bar', '5.6.7.8:/foo/bar'])


### PR DESCRIPTION
Add a helper function to rsync a filesystem tree to multiple targets.

It will be used by the master to sync pool and lists after pulling updates.