### PR TITLE
Add and cleanup module docstrings

### DIFF
--- a/lib/archive_auth_mirror/scripts/reprepro_sign_helper.py
+++ b/lib/archive_auth_mirror/scripts/reprepro_sign_helper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+"""Helper for reprepro to sign archive lists."""
 
 import sys
 import argparse

--- a/lib/archive_auth_mirror/utils.py
+++ b/lib/archive_auth_mirror/utils.py
@@ -1,3 +1,5 @@
+"""Miscellaneous helper functions."""
+
 from pathlib import Path
 
 

--- a/lib/charms/archive_auth_mirror/repository.py
+++ b/lib/charms/archive_auth_mirror/repository.py
@@ -1,3 +1,5 @@
+"""Repository configuration functions."""
+
 import getpass
 
 import yaml

--- a/lib/charms/archive_auth_mirror/setup.py
+++ b/lib/charms/archive_auth_mirror/setup.py
@@ -1,3 +1,5 @@
+"""Service installation and configuration functions."""
+
 from pathlib import Path
 
 from charmhelpers.core import hookenv, host

--- a/reactive/archive_auth_mirror.py
+++ b/reactive/archive_auth_mirror.py
@@ -1,3 +1,5 @@
+"""Install and configure archive-auth-mirror to mirror an Ubuntu repository."""
+
 from charmhelpers.core import hookenv
 
 from charms.reactive import when, when_not, set_state, remove_state, only_once

--- a/unit_tests/test_cron.py
+++ b/unit_tests/test_cron.py
@@ -1,16 +1,16 @@
 from pathlib import Path
 
-from fixtures import TestWithFixtures, TempDir
+from charmtest import CharmTest
 
 from archive_auth_mirror.utils import get_paths
 from archive_auth_mirror.cron import install_crontab, remove_crontab
 
 
-class InstallCrontabTest(TestWithFixtures):
+class InstallCrontabTest(CharmTest):
 
     def test_install_crontab(self):
         """install_crontab creates a crontab file"""
-        root_dir = Path(self.useFixture(TempDir()).path)
+        root_dir = Path(self.fakes.fs.root.path)
         (root_dir / 'etc/cron.d').mkdir(parents=True)
         paths = get_paths(root_dir=root_dir)
         install_crontab(paths=paths)
@@ -22,13 +22,13 @@ class InstallCrontabTest(TestWithFixtures):
         self.assertIn(str(script), content)
 
 
-class RemoveCrontabTest(TestWithFixtures):
+class RemoveCrontabTest(CharmTest):
 
     def setUp(self):
         super().setUp()
-        self.root_dir = Path(self.useFixture(TempDir()).path)
-        (self.root_dir / 'etc/cron.d').mkdir(parents=True)
-        self.paths = get_paths(root_dir=self.root_dir)
+        root_dir = Path(self.fakes.fs.root.path)
+        (root_dir / 'etc/cron.d').mkdir(parents=True)
+        self.paths = get_paths(root_dir=root_dir)
 
     def test_remove_crontab(self):
         """remove_crontab removes the crontab file."""

--- a/unit_tests/test_manage_user.py
+++ b/unit_tests/test_manage_user.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from fixtures import TestWithFixtures, TempDir
+from charmtest import CharmTest
 
 from archive_auth_mirror.scripts.manage_user import (
     add_user,
@@ -9,12 +9,11 @@ from archive_auth_mirror.scripts.manage_user import (
 )
 
 
-class ManageUserTest(TestWithFixtures):
+class ManageUserTest(CharmTest):
 
     def setUp(self):
         super().setUp()
-        tempdir = self.useFixture(TempDir())
-        self.auth_file = Path(tempdir.path) / 'auth-file'
+        self.auth_file = Path(self.fakes.fs.root.path) / 'auth-file'
         self.auth_file.touch()
 
     def test_add_user(self):

--- a/unit_tests/test_script.py
+++ b/unit_tests/test_script.py
@@ -2,12 +2,12 @@ from pathlib import Path
 
 import yaml
 
-from fixtures import TestWithFixtures, TempDir
+from charmtest import CharmTest
 
 from archive_auth_mirror.script import get_config
 
 
-class GetConfigTest(TestWithFixtures):
+class GetConfigTest(CharmTest):
 
     def test_config_not_found(self):
         """If the config file is not found, get_config returns {}."""
@@ -15,7 +15,7 @@ class GetConfigTest(TestWithFixtures):
 
     def test_load_config(self):
         """If the file is found, it's content is returned as YAML."""
-        tempdir = Path(self.useFixture(TempDir()).path)
+        tempdir = Path(self.fakes.fs.root.path)
         config_file = tempdir / 'config.yaml'
 
         config = {'value1': 30, 'value2': 'foo'}


### PR DESCRIPTION
Just trivial cleanups:
 - add a few module docstrings
 - use CharmTest as test base class for tests requiring a tempdir instead of TestWithFixtures + TempDir