### PR TITLE
Rsync the repository to non-leader units

### DIFF
--- a/lib/archive_auth_mirror/rsync.py
+++ b/lib/archive_auth_mirror/rsync.py
@@ -3,7 +3,7 @@
 import subprocess
 
 
-def rsync(path, host, delete=False):
+def rsync(path, host, rsh=None, delete=False):
     """Copy a filesytem tree using rsync.
 
     The path is synced at the same location on the remote host.
@@ -16,13 +16,15 @@ def rsync(path, host, delete=False):
     """
     path = str(path.absolute())
     command = ['/usr/bin/rsync', '-a']
+    if rsh is not None:
+        command.extend(['--rsh', rsh])
     if delete:
         command.append('--delete')
     command.extend([path, '{}:{}'.format(host, path)])
     subprocess.check_output(command)
 
 
-def rsync_multi(path, hosts, logger, delete=False):
+def rsync_multi(path, hosts, logger, rsh=None, delete=False):
     """Copy a filesystem tree using rsync to multiple hosts.
 
     If a call to rsync to a host fails, the error is logged via the provided
@@ -31,7 +33,8 @@ def rsync_multi(path, hosts, logger, delete=False):
     """
     for host in hosts:
         try:
-            rsync(path, host, delete=delete)
+            logger.info('rsyncing {} to {}'.format(path, host))
+            rsync(path, host, rsh=rsh, delete=delete)
         except subprocess.CalledProcessError as error:
             logger.error(
                 'rsync to {} failed: {}'.format(host, error.output))

--- a/lib/archive_auth_mirror/rsync.py
+++ b/lib/archive_auth_mirror/rsync.py
@@ -3,7 +3,7 @@
 import subprocess
 
 
-def rsync(path, host, rsh=None, delete=False):
+def rsync(host, path, rsh=None, delete=False):
     """Copy a filesytem tree using rsync.
 
     The path is synced at the same location on the remote host.
@@ -24,7 +24,7 @@ def rsync(path, host, rsh=None, delete=False):
     subprocess.check_output(command)
 
 
-def rsync_multi(path, hosts, logger, rsh=None, delete=False):
+def rsync_multi(hosts, path, logger, rsh=None, delete=False):
     """Copy a filesystem tree using rsync to multiple hosts.
 
     If a call to rsync to a host fails, the error is logged via the provided
@@ -34,7 +34,7 @@ def rsync_multi(path, hosts, logger, rsh=None, delete=False):
     for host in hosts:
         try:
             logger.info('rsyncing {} to {}'.format(path, host))
-            rsync(path, host, rsh=rsh, delete=delete)
+            rsync(host, path, rsh=rsh, delete=delete)
         except subprocess.CalledProcessError as error:
             logger.error(
                 'rsync to {} failed: {}'.format(host, error.output))

--- a/lib/archive_auth_mirror/scripts/mirror_archive.py
+++ b/lib/archive_auth_mirror/scripts/mirror_archive.py
@@ -5,6 +5,7 @@ import sys
 
 from ..utils import get_paths
 from ..reprepro import Reprepro
+from ..rsync import rsync_multi
 from ..script import (
     setup_logger,
     get_config,
@@ -14,17 +15,49 @@ from ..script import (
 def main():
     logger = setup_logger(echo=True)
     paths = get_paths()
-    suite = get_config(paths['config'])['suite']
+    config = get_config(paths['config'])
+    suite = config['suite']
+    other_units = config['ssh-peers'].keys()
+    # Using StrictHostKeyChecking=no isn't ideal, but we don't yet
+    # popolate known_hosts with the right keys. But we trust the
+    # network, and we don't push any sensitive data.
+    rsh = 'ssh -o StrictHostKeyChecking=no -i {}'.format(paths['ssh-key'])
 
     logger.info('starting mirroring')
 
     reprepro = Reprepro(logger)
     try:
+        logger.info('fetching new pool packages')
         reprepro.execute(
             '--show-percent', '--export=never', '--keepunreferencedfiles',
             'update', suite)
+
+        logger.info('rsyncing new pool packages to peer units')
+        rsync_multi(paths['static'] / 'ubuntu', other_units, logger, rsh=rsh)
+
+        logger.info('generating new dists directory')
         reprepro.execute('export', suite)
+
+        logger.info('rsyncing new dists directory to peer units')
+        rsync_multi(
+            paths['static'] / 'ubuntu' / 'dists', other_units, logger, rsh=rsh)
+
+        logger.info('deleting old pool packages')
         reprepro.execute('deleteunreferenced')
+
+        logger.info('deleting old pool packages on peer units')
+        rsync_multi(
+            paths['static'] / 'ubuntu', other_units, logger, rsh=rsh,
+            delete=True)
+
+        logger.info('rsyncing reprepro dir to peer units')
+        # Push only the reprepro db, not the conf dir. Each unit should
+        # generate the conf dir themselves, so we don't push it, since
+        # it contains the private signing key, which is sensitive data.
+        rsync_multi(
+            paths['reprepro'] / 'reprepro', other_units, logger, rsh=rsh,
+            delete=True)
+
         logger.info('mirroring completed')
     except subprocess.CalledProcessError:
         logger.error('mirroring failed')

--- a/lib/archive_auth_mirror/scripts/mirror_archive.py
+++ b/lib/archive_auth_mirror/scripts/mirror_archive.py
@@ -51,11 +51,15 @@ def main():
             delete=True)
 
         logger.info('rsyncing reprepro dir to peer units')
-        # Push only the reprepro db, not the conf dir. Each unit should
-        # generate the conf dir themselves, so we don't push it, since
-        # it contains the private signing key, which is sensitive data.
+        # Push only the reprepro db and lists, not the conf dir. Each
+        # unit should generate the conf dir themselves, so we don't push
+        # it, since it contains the private signing key, which is
+        # sensitive data.
         rsync_multi(
-            paths['reprepro'] / 'reprepro', other_units, logger, rsh=rsh,
+            paths['reprepro'] / 'db', other_units, logger, rsh=rsh,
+            delete=True)
+        rsync_multi(
+            paths['reprepro'] / 'lists', other_units, logger, rsh=rsh,
             delete=True)
 
         logger.info('mirroring completed')

--- a/unit_tests/test_rsync.py
+++ b/unit_tests/test_rsync.py
@@ -13,14 +13,14 @@ class RsyncTest(TestCase):
     @mock.patch('subprocess.check_output')
     def test_rsync(self, mock_check_output):
         """The rsync copies a filesytem tree using rsync."""
-        rsync(Path('/foo/bar'), '1.2.3.4')
+        rsync('1.2.3.4', Path('/foo/bar'))
         mock_check_output.assert_called_with(
             ['/usr/bin/rsync', '-a', '/foo/bar', '1.2.3.4:/foo/bar'])
 
     @mock.patch('subprocess.check_output')
     def test_rsync_delete(self, mock_check_output):
         """If the delete flag is True, the --delete option is passed."""
-        rsync(Path('/foo/bar'), '1.2.3.4', delete=True)
+        rsync('1.2.3.4', Path('/foo/bar'), delete=True)
         mock_check_output.assert_called_with(
             ['/usr/bin/rsync', '-a', '--delete', '/foo/bar',
              '1.2.3.4:/foo/bar'])
@@ -28,7 +28,7 @@ class RsyncTest(TestCase):
     @mock.patch('subprocess.check_output')
     def test_rsync_rsh(self, mock_check_output):
         """If the rsh flag is not None, the --rsh option is passed."""
-        rsync(Path('/foo/bar'), '1.2.3.4', rsh='ssh -i my-identity')
+        rsync('1.2.3.4', Path('/foo/bar'), rsh='ssh -i my-identity')
         mock_check_output.assert_called_with(
             ['/usr/bin/rsync', '-a', '--rsh', 'ssh -i my-identity', '/foo/bar',
              '1.2.3.4:/foo/bar'])
@@ -44,7 +44,7 @@ class RsyncMultiTest(TestWithFixtures):
     def test_each_host(self, mock_check_output):
         """The rsync call is performed for each host."""
         rsync_multi(
-            Path('/foo/bar'), ['1.2.3.4', '5.6.7.8'], logging.getLogger())
+            ['1.2.3.4', '5.6.7.8'], Path('/foo/bar'), logging.getLogger())
         mock_check_output.assert_has_calls(
             [mock.call(
                 ['/usr/bin/rsync', '-a', '/foo/bar', '1.2.3.4:/foo/bar']),
@@ -61,7 +61,7 @@ class RsyncMultiTest(TestWithFixtures):
 
         mock_check_output.side_effect = check_output
         rsync_multi(
-            Path('/foo/bar'), ['1.2.3.4', '5.6.7.8'], logging.getLogger())
+            ['1.2.3.4', '5.6.7.8'], Path('/foo/bar'), logging.getLogger())
         self.assertIn(
             'rsync to 1.2.3.4 failed: something failed\n', self.logger.output)
         # rsync to the second host is exectuted too
@@ -72,7 +72,7 @@ class RsyncMultiTest(TestWithFixtures):
     def test_rsh(self, mock_check_output):
         """The rsh flag is passed through."""
         rsync_multi(
-            Path('/foo/bar'), ['1.2.3.4'], logging.getLogger(),
+            ['1.2.3.4'], Path('/foo/bar'), logging.getLogger(),
             rsh='ssh -i my-identity')
         mock_check_output.assert_called_with(
             ['/usr/bin/rsync', '-a', '--rsh', 'ssh -i my-identity', '/foo/bar',


### PR DESCRIPTION
Rsync the relevant content to the non-leader units after each step in the mirror script:

Now the repository will be properly replicated to all units, and any unit can take over if the leader dies.

