### PR TITLE
Add a slash to the rsync paths.

### DIFF
--- a/lib/archive_auth_mirror/rsync.py
+++ b/lib/archive_auth_mirror/rsync.py
@@ -14,7 +14,7 @@ def rsync(host, path, rsh=None, delete=False):
     the destination.
 
     """
-    path = str(path.absolute())
+    path = str(path.absolute()) + '/'
     command = ['/usr/bin/rsync', '-a']
     if rsh is not None:
         command.extend(['--rsh', rsh])

--- a/unit_tests/test_rsync.py
+++ b/unit_tests/test_rsync.py
@@ -15,23 +15,23 @@ class RsyncTest(TestCase):
         """The rsync copies a filesytem tree using rsync."""
         rsync('1.2.3.4', Path('/foo/bar'))
         mock_check_output.assert_called_with(
-            ['/usr/bin/rsync', '-a', '/foo/bar', '1.2.3.4:/foo/bar'])
+            ['/usr/bin/rsync', '-a', '/foo/bar/', '1.2.3.4:/foo/bar/'])
 
     @mock.patch('subprocess.check_output')
     def test_rsync_delete(self, mock_check_output):
         """If the delete flag is True, the --delete option is passed."""
         rsync('1.2.3.4', Path('/foo/bar'), delete=True)
         mock_check_output.assert_called_with(
-            ['/usr/bin/rsync', '-a', '--delete', '/foo/bar',
-             '1.2.3.4:/foo/bar'])
+            ['/usr/bin/rsync', '-a', '--delete', '/foo/bar/',
+             '1.2.3.4:/foo/bar/'])
 
     @mock.patch('subprocess.check_output')
     def test_rsync_rsh(self, mock_check_output):
         """If the rsh flag is not None, the --rsh option is passed."""
         rsync('1.2.3.4', Path('/foo/bar'), rsh='ssh -i my-identity')
         mock_check_output.assert_called_with(
-            ['/usr/bin/rsync', '-a', '--rsh', 'ssh -i my-identity', '/foo/bar',
-             '1.2.3.4:/foo/bar'])
+            ['/usr/bin/rsync', '-a', '--rsh', 'ssh -i my-identity',
+             '/foo/bar/', '1.2.3.4:/foo/bar/'])
 
 
 class RsyncMultiTest(TestWithFixtures):
@@ -47,9 +47,9 @@ class RsyncMultiTest(TestWithFixtures):
             ['1.2.3.4', '5.6.7.8'], Path('/foo/bar'), logging.getLogger())
         mock_check_output.assert_has_calls(
             [mock.call(
-                ['/usr/bin/rsync', '-a', '/foo/bar', '1.2.3.4:/foo/bar']),
+                ['/usr/bin/rsync', '-a', '/foo/bar/', '1.2.3.4:/foo/bar/']),
              mock.call(
-                 ['/usr/bin/rsync', '-a', '/foo/bar', '5.6.7.8:/foo/bar'])])
+                 ['/usr/bin/rsync', '-a', '/foo/bar/', '5.6.7.8:/foo/bar/'])])
 
     @mock.patch('subprocess.check_output')
     def test_log_failures(self, mock_check_output):
@@ -66,7 +66,7 @@ class RsyncMultiTest(TestWithFixtures):
             'rsync to 1.2.3.4 failed: something failed\n', self.logger.output)
         # rsync to the second host is exectuted too
         mock_check_output.assert_any_call(
-            ['/usr/bin/rsync', '-a', '/foo/bar', '5.6.7.8:/foo/bar'])
+            ['/usr/bin/rsync', '-a', '/foo/bar/', '5.6.7.8:/foo/bar/'])
 
     @mock.patch('subprocess.check_output')
     def test_rsh(self, mock_check_output):
@@ -75,5 +75,5 @@ class RsyncMultiTest(TestWithFixtures):
             ['1.2.3.4'], Path('/foo/bar'), logging.getLogger(),
             rsh='ssh -i my-identity')
         mock_check_output.assert_called_with(
-            ['/usr/bin/rsync', '-a', '--rsh', 'ssh -i my-identity', '/foo/bar',
-             '1.2.3.4:/foo/bar'])
+            ['/usr/bin/rsync', '-a', '--rsh', 'ssh -i my-identity',
+             '/foo/bar/', '1.2.3.4:/foo/bar/'])


### PR DESCRIPTION
Add a trailing slash to the rsync paths, otherwise the slave units end up with
and ubuntu directory within the ubuntu directory.