### PR TITLE
Save the public GPG key

### DIFF
--- a/lib/archive_auth_mirror/gpg.py
+++ b/lib/archive_auth_mirror/gpg.py
@@ -28,6 +28,16 @@ def import_keys(mirror_key, sign_key, gnupghome=None):
         fingerprint(imported_mirror_key), fingerprint(imported_sign_key))
 
 
+def export_public_key(key_id, path, gnupghome=None):
+    """Export a public key in ASCII format to the specified path."""
+    if not gnupghome:
+        gnupghome = str(get_paths()['gnupghome'])
+    gpg = gnupg.GPG(homedir=gnupghome)
+    material = gpg.export_keys(key_id)
+    with path.open('w') as fh:
+        fh.write(material)
+
+
 def inline_sign(key_id, unsigned_file, inline_sign_file, paths=None):
     """Create an inline-signed file."""
     _sign(

--- a/reactive/archive_auth_mirror.py
+++ b/reactive/archive_auth_mirror.py
@@ -80,6 +80,8 @@ def config_set():
     repository.configure_reprepro(
         config['mirror-uri'].strip(), config['mirror-archs'].strip(),
         fingerprints.mirror, fingerprints.sign, sign_gpg_passphrase)
+    # export the public key used to sign the repository
+    _export_sign_key(fingerprints.sign)
     hookenv.status_set('active', 'Mirroring configured')
 
 
@@ -110,3 +112,9 @@ def _configure_static_serve():
     vhost_config = setup.get_virtualhost_config()
     configure_site(
         'archive-auth-mirror', 'nginx-static.j2', **vhost_config)
+
+
+def _export_sign_key(key_id):
+    """Export the public key for the repo under the static serve."""
+    filename = utils.get_paths()['static'] / 'key.asc'
+    gpg.export_public_key(key_id, filename)

--- a/unit_tests/test_gpg.py
+++ b/unit_tests/test_gpg.py
@@ -5,6 +5,7 @@ from charmtest import CharmTest
 from archive_auth_mirror.utils import get_paths
 from archive_auth_mirror.gpg import (
     import_keys,
+    export_public_key,
     inline_sign,
     detach_sign,
 )
@@ -115,6 +116,24 @@ class ImportKeysTest(CharmTest):
         self.assertEqual(
             (PUBLIC_KEY_FINGERPRINT[-8:], SECRET_KEY_FINGERPRINT[-8:]),
             fingerprints)
+
+
+class ExportPublicKeyTest(CharmTest):
+
+    def test_export_public_key(self):
+        """export_public_key exports the specified public key."""
+        gnupghome = self.fakes.fs.root.path
+        public_key_file = Path(self.fakes.fs.root.path) / 'public.asc'
+        fingerprints = import_keys(
+            PUBLIC_KEY_MATERIAL, SECRET_KEY_MATERIAL,
+            gnupghome=gnupghome)
+        export_public_key(
+            fingerprints.sign, public_key_file, gnupghome=gnupghome)
+        material = public_key_file.read_text()
+        self.assertTrue(
+            material.startswith('-----BEGIN PGP PUBLIC KEY BLOCK-----'))
+        self.assertTrue(
+            material.endswith('-----END PGP PUBLIC KEY BLOCK-----\n'))
 
 
 class InlineSignTest(CharmTest):


### PR DESCRIPTION
Export the public key used to sign the repository when keys are configured.
It's made available at the document root of the static serve.
This mainly for easiness of retrieval for testing, the script to configure the repository will have the key embedded.