### PR TITLE
Insert Packages-Require-Authorization field into Release files

### DIFF
--- a/lib/archive_auth_mirror/scripts/reprepro_sign_helper.py
+++ b/lib/archive_auth_mirror/scripts/reprepro_sign_helper.py
@@ -21,6 +21,18 @@ def parse_args(args=None):
     return parser.parse_args(args=args)
 
 
+def patch_release_file(path):
+    """Insert some custom fields in the Release file."""
+    patch_path = path.with_suffix(".patched")
+    with path.open() as file:
+        with patch_path.open("x") as outfile:
+            for line in file:
+                if line.startswith("MD5Sum:"):
+                    outfile.write("Packages-Require-Authorization: yes\n")
+                outfile.write(line)
+    patch_path.rename(path)
+
+
 def main():
     logger = setup_logger()
     config = get_config()
@@ -31,6 +43,7 @@ def main():
 
     args = parse_args()
     unsigned_file = Path(args.unsigned_file)
+    patch_release_file(unsigned_file)
     if args.inline_sign_file:
         inline_sign(sign_key, unsigned_file, Path(args.inline_sign_file))
     if args.detach_sign_file:


### PR DESCRIPTION
[UNTESTED as part of the code, only tested the function outside it]

This tells APT that the repository requires authorization for
packages. This can be helpful for example, to prevent tools
from trying to use an authorization-requiring repository after
credentials have been removed from the system.

Support for APT is being landed as part of

https://salsa.debian.org/apt-team/apt/merge_requests/40/diffs