### PR TITLE
Updates to be able to build and push the charm with new charm cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 CHARM_NAME = archive-auth-mirror
 CHARM_SERIES = xenial
-CHARM_OUTPUT = build/charm-output
+CHARM_OUTPUT := $(shell mktemp -d)
 RENDERED_CHARM_DIR = $(CHARM_OUTPUT)/$(CHARM_SERIES)/$(CHARM_NAME)
-CHARM_URI = cs:~landscape/$(CHARM_NAME)
+CHARM_URI = cs:~yellow/$(CHARM_NAME)
 
 
 .PHONY: help
@@ -19,7 +19,7 @@ install-deps:  ## Install test dependency deb packages
 
 .PHONY: charm-build
 charm-build: REV_HASH = $(shell git rev-parse HEAD)
-charm-build: export INTERFACE_PATH = interfaces
+charm-build: export CHARM_INTERFACES_DIR = interfaces
 charm-build: ## Build the charm
 	rm -rf $(CHARM_OUTPUT)
 	mkdir -p $(CHARM_OUTPUT)

--- a/release-charm
+++ b/release-charm
@@ -21,15 +21,5 @@ rm $OUT
 REV_HASH=$(awk '{ print $NF; }' "$RENDERED_CHARM_DIR"/repo-info)
 
 # publish the charm
-charm set $PUSHED_CHARM revision=$REV_HASH
-charm grant $PUSHED_CHARM --acl read --set everyone
 charm release $PUSHED_CHARM --channel=edge
-
-# tag the repo with the charm revision
-if ! git remote | grep -q $GIT_UPSTREAM_REMOTE; then
-    git remote add $GIT_UPSTREAM $GIT_UPSTREAM_REPO
-fi
-
-GIT_TAG=charm-r${PUSHED_CHARM_REV}
-git tag $GIT_TAG $REV_HASH
-git push $GIT_UPSTREAM_REMOTE $GIT_TAG
+charm grant $PUSHED_CHARM --acl read --set everyone


### PR DESCRIPTION
The charm cannot be built anymore in a subdirectory.
Environment variable for interfaces has been changed.
The release-charm script didn't work.