### PR TITLE
Include the resource name in the nginx configuration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3,6 +3,10 @@ options:
     type: string
     description: "The URL of the service."
     default: ""
+  resource-name:
+    type: string
+    description: "The name of the resource associated with this service"
+    default: esm
   repository-origin:
     type: string
     description: "The value of the 'Origin' field of the repository."

--- a/lib/charms/archive_auth_mirror/setup.py
+++ b/lib/charms/archive_auth_mirror/setup.py
@@ -19,7 +19,7 @@ def get_virtualhost_name(hookenv=hookenv):
 
 
 def get_virtualhost_config(
-        auth_backends, auth_cache_enabled, auth_cache_duration,
+        auth_backends, resource_name, auth_cache_enabled, auth_cache_duration,
         auth_cache_inactivity, hookenv=hookenv):
     """Return the configuration for the static virtuahost."""
     paths = get_paths()
@@ -28,6 +28,7 @@ def get_virtualhost_config(
         'domain': domain,
         'document_root': str(paths['static']),
         'auth_backends': auth_backends or [],
+        'resource_name': resource_name,
         'auth_cache_enabled': auth_cache_enabled,
         'auth_cache_duration': auth_cache_duration,
         'auth_cache_inactivity': auth_cache_inactivity,

--- a/reactive/archive_auth_mirror.py
+++ b/reactive/archive_auth_mirror.py
@@ -28,6 +28,7 @@ NGINX_OPTIONS = (
     'auth-cache-duration',
     'auth-cache-enabled',
     'auth-cache-inactivity',
+    'resource-name',
 )
 
 
@@ -176,8 +177,8 @@ def _configure_static_serve(auth_backends=None):
     """Configure the static file serve."""
     cfg = hookenv.config()
     vhost_config = setup.get_virtualhost_config(
-        auth_backends, cfg['auth-cache-enabled'], cfg['auth-cache-duration'],
-        cfg['auth-cache-inactivity'])
+        auth_backends, cfg['resource-name'], cfg['auth-cache-enabled'],
+        cfg['auth-cache-duration'], cfg['auth-cache-inactivity'])
     configure_site('archive-auth-mirror', 'nginx-static.j2', **vhost_config)
 
 

--- a/templates/nginx-static.j2
+++ b/templates/nginx-static.j2
@@ -49,6 +49,7 @@ server {
       {%- endif %}
         proxy_pass http://auth_backend/auth-check/;
         proxy_set_header Original-URI $request_uri;
+        proxy_set_header Resource-Name {{ resource_name }};
     }
   {%- endif %}
 }

--- a/unit_tests/test_setup.py
+++ b/unit_tests/test_setup.py
@@ -39,7 +39,13 @@ class GetVirtualhostConfigTest(CharmTest):
     def test_virtualhost_config(self):
         """get_virtualhost_config returns the config for the virtualhost."""
         hookenv = FakeHookEnv()
-        config = get_virtualhost_config([], False, "", "", hookenv=hookenv)
+        auth_backends = []
+        resource_name = 'esm'
+        auth_cache_enabled = False
+        auth_cache_duration = auth_cache_inactivity = ""
+        config = get_virtualhost_config(
+            auth_backends, resource_name, auth_cache_enabled,
+            auth_cache_duration, auth_cache_inactivity, hookenv=hookenv)
         self.assertEqual(
             {'domain': '1.2.3.4',
              'document_root': '/srv/archive-auth-mirror/static',
@@ -47,15 +53,20 @@ class GetVirtualhostConfigTest(CharmTest):
              'auth_cache_enabled': False,
              'auth_cache_duration': "",
              'auth_cache_inactivity': "",
-             'basic_auth_file': '/srv/archive-auth-mirror/basic-auth'},
+             'basic_auth_file': '/srv/archive-auth-mirror/basic-auth',
+             'resource_name': 'esm'},
             config)
 
     def test_virtualhost_config_auth_backends(self):
         """If backends are passed, they're included in the vhost config."""
         hookenv = FakeHookEnv()
         auth_backends = [('1.2.3.4', '8080'), ('5.6.7.8', '9090')]
+        resource_name = 'fips'
+        auth_cache_enabled = False
+        auth_cache_duration = auth_cache_inactivity = ""
         config = get_virtualhost_config(
-            auth_backends, False, "", "", hookenv=hookenv)
+            auth_backends, resource_name, auth_cache_enabled,
+            auth_cache_duration, auth_cache_inactivity, hookenv=hookenv)
         self.assertEqual(
             {'domain': '1.2.3.4',
              'document_root': '/srv/archive-auth-mirror/static',
@@ -63,13 +74,20 @@ class GetVirtualhostConfigTest(CharmTest):
              'auth_cache_enabled': False,
              'auth_cache_duration': "",
              'auth_cache_inactivity': "",
-             'basic_auth_file': '/srv/archive-auth-mirror/basic-auth'},
+             'basic_auth_file': '/srv/archive-auth-mirror/basic-auth',
+             'resource_name': 'fips'},
             config)
 
     def test_virtualhost_config_auth_cache_time(self):
         """If caching time is passed, it's included in the vhost config."""
         hookenv = FakeHookEnv()
-        config = get_virtualhost_config([], True, "1h", "5m", hookenv=hookenv)
+        auth_backends = []
+        resource_name = 'esm-apps'
+        auth_cache_enabled = True
+        auth_cache_duration, auth_cache_inactivity = "1h", "5m"
+        config = get_virtualhost_config(
+            auth_backends, resource_name, auth_cache_enabled,
+            auth_cache_duration, auth_cache_inactivity, hookenv=hookenv)
         self.assertEqual(
             {'domain': '1.2.3.4',
              'document_root': '/srv/archive-auth-mirror/static',
@@ -77,7 +95,8 @@ class GetVirtualhostConfigTest(CharmTest):
              'auth_cache_enabled': True,
              'auth_cache_duration': "1h",
              'auth_cache_inactivity': "5m",
-             'basic_auth_file': '/srv/archive-auth-mirror/basic-auth'},
+             'basic_auth_file': '/srv/archive-auth-mirror/basic-auth',
+             'resource_name': 'esm-apps'},
             config)
 
 


### PR DESCRIPTION
The resource name (by default "esm") is now passed as part of the authorization request to the esm-auth-server. This way the ESM auth server does not have to hardcode that value, and can potentially be used to server authorization for multiple mirrors (esm, fips, etc).